### PR TITLE
Change callback value names in builders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.1" // your current series x.y
+ThisBuild / tlBaseVersion := "0.2" // your current series x.y
 
 ThisBuild / organization := "com.permutive"
 ThisBuild / organizationName := "Permutive"


### PR DESCRIPTION
Having a value with the same name as a method confuses the Scala 3 compiler:

![image](https://user-images.githubusercontent.com/1926225/202190815-e64dd3fc-b7b1-4143-9d58-d152fc4da885.png)
