### PR TITLE
Have just one refreshable implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.2" // your current series x.y
+ThisBuild / tlBaseVersion := "1.0" // your current series x.y
 
 ThisBuild / organization := "com.permutive"
 ThisBuild / organizationName := "Permutive"

--- a/core/src/test/scala/com/permutive/refreshable/RefreshableSuite.scala
+++ b/core/src/test/scala/com/permutive/refreshable/RefreshableSuite.scala
@@ -367,13 +367,12 @@ class RefreshableSuite extends CatsEffectSuite {
 
   test("See all updates") {
     val run = IO.ref(0).flatMap { state =>
-      Refreshable.builder(state.getAndUpdate(_ + 1)).withUpdates.resource.use {
-        r =>
-          r.updates
-            .take(5)
-            .compile
-            .toList
-            .assertEquals(List.range(0, 5).map(CachedValue.Success(_)))
+      Refreshable.builder(state.getAndUpdate(_ + 1)).resource.use { r =>
+        r.updates
+          .take(5)
+          .compile
+          .toList
+          .assertEquals(List.range(0, 5).map(CachedValue.Success(_)))
       }
     }
 
@@ -425,7 +424,6 @@ class RefreshableSuite extends CatsEffectSuite {
         .cacheDuration(cacheDuration)
         .onRefreshFailure(onRefreshFailure)
         .onExhaustedRetries(onExhaustedRetries)
-        .withUpdates
 
       val b2 = onNewValue.fold(b1)(v => b1.onNewValue(v))
 


### PR DESCRIPTION
Move the `updates` method to the main class and make `Refreshable` an abstract class.